### PR TITLE
stories: PSQ-first view — sort by PSQ, PSQ left of title

### DIFF
--- a/site/src/lib/db-stories.ts
+++ b/site/src/lib/db-stories.ts
@@ -184,7 +184,7 @@ function scoreRowToScore(row: ScoreRow): Score {
 }
 
 export type SortOption = 'top' | 'time' | 'time_asc' | 'score_desc' | 'score_asc' | 'hn_points' | 'hn_points_asc' | 'conf_desc' | 'conf_asc' | 'setl_desc' | 'setl_asc' | 'velocity' | 'psq_desc' | 'psq_asc' | 'editorial_desc' | 'editorial_asc' | 'structural_desc' | 'structural_asc';
-export type FilterOption = 'all' | 'evaluated' | 'positive' | 'negative' | 'neutral' | 'pending' | 'failed';
+export type FilterOption = 'all' | 'evaluated' | 'positive' | 'negative' | 'neutral' | 'pending' | 'failed' | 'psq_safe' | 'psq_mixed' | 'psq_threat';
 export type TypeOption = 'all' | 'ask' | 'show' | 'job';
 export type ContentTypeOption = 'all' | 'ED' | 'PO' | 'LP' | 'PR' | 'AC' | 'MI';
 export type ModelOption = string; // 'all' or a model ID like 'claude-haiku-4-5-20251001'
@@ -245,6 +245,9 @@ export async function getFilteredStoriesWithScores(
     case 'positive': conditions.push("s.eval_status = 'done' AND COALESCE(s.hcb_weighted_mean, s.hcb_editorial_mean) > 0.05"); break;
     case 'negative': conditions.push("s.eval_status = 'done' AND COALESCE(s.hcb_weighted_mean, s.hcb_editorial_mean) < -0.05"); break;
     case 'neutral': conditions.push("s.eval_status = 'done' AND COALESCE(s.hcb_weighted_mean, s.hcb_editorial_mean) BETWEEN -0.05 AND 0.05"); break;
+    case 'psq_safe': conditions.push("s.psq_score IS NOT NULL AND s.psq_score > 6"); break;
+    case 'psq_mixed': conditions.push("s.psq_score IS NOT NULL AND s.psq_score BETWEEN 4 AND 6"); break;
+    case 'psq_threat': conditions.push("s.psq_score IS NOT NULL AND s.psq_score < 4"); break;
     case 'pending': conditions.push("s.eval_status IN ('pending', 'queued', 'evaluating')"); break;
     case 'failed': conditions.push("s.eval_status IN ('failed', 'skipped')"); break;
   }

--- a/site/src/pages/stories.astro
+++ b/site/src/pages/stories.astro
@@ -12,7 +12,7 @@ import { readDb } from '../lib/db-utils';
 const db = readDb(Astro.locals.runtime.env.DB);
 
 const url = new URL(Astro.request.url);
-const sort = (url.searchParams.get('sort') || 'top') as SortOption;
+const sort = (url.searchParams.get('sort') || 'psq_desc') as SortOption;
 const filter = (url.searchParams.get('filter') || 'all') as FilterOption;
 const type = (url.searchParams.get('type') || 'all') as TypeOption;
 const ctype = (url.searchParams.get('ctype') || 'all') as ContentTypeOption;
@@ -31,10 +31,10 @@ const safeTemporal = validTemporal.includes(temporalRaw) ? temporalRaw : '';
 const hasSupplFilter = !!(safePt || safeJargon || safeTemporal);
 
 const validSorts: SortOption[] = ['top', 'time', 'time_asc', 'score_desc', 'score_asc', 'hn_points', 'hn_points_asc', 'conf_desc', 'conf_asc', 'velocity', 'psq_desc', 'psq_asc', 'editorial_desc', 'editorial_asc', 'structural_desc', 'structural_asc'];
-const validFilters: FilterOption[] = ['all', 'evaluated', 'positive', 'negative', 'neutral', 'pending', 'failed'];
+const validFilters: FilterOption[] = ['all', 'evaluated', 'positive', 'negative', 'neutral', 'pending', 'failed', 'psq_safe', 'psq_mixed', 'psq_threat'];
 const validTypes: TypeOption[] = ['all', 'ask', 'show', 'job'];
 const validCtypes: ContentTypeOption[] = ['all', 'ED', 'PO', 'LP', 'PR', 'AC', 'MI'];
-const safeSort = validSorts.includes(sort) ? sort : 'top';
+const safeSort = validSorts.includes(sort) ? sort : 'psq_desc';
 const safeFilter = validFilters.includes(filter) ? filter : 'all';
 const safeType = validTypes.includes(type) ? type : 'all';
 const safeCtype = validCtypes.includes(ctype) ? ctype : 'all';
@@ -105,7 +105,7 @@ function buildUrl(params: Record<string, string>): string {
   const ct = params.ctype ?? safeCtype;
   const m = params.model ?? safeModel;
   const pg = params.p ?? '1';
-  if (s !== 'top') p.set('sort', s);
+  if (s !== 'psq_desc') p.set('sort', s);
   if (f !== 'all') p.set('filter', f);
   if (t !== 'all') p.set('type', t);
   if (ct !== 'all') p.set('ctype', ct);
@@ -122,7 +122,7 @@ function buildUrl(params: Record<string, string>): string {
 // Build URL preserving all current params except suppl signal filters
 function buildClearSupplUrl(): string {
   const p = new URLSearchParams();
-  if (safeSort !== 'top') p.set('sort', safeSort);
+  if (safeSort !== 'psq_desc') p.set('sort', safeSort);
   if (safeFilter !== 'all') p.set('filter', safeFilter);
   if (safeType !== 'all') p.set('type', safeType);
   if (safeCtype !== 'all') p.set('ctype', safeCtype);
@@ -134,7 +134,7 @@ function buildClearSupplUrl(): string {
 const pageTitle = safeType === 'ask' ? 'Ask HN' : safeType === 'show' ? 'Show HN' : safeType === 'job' ? 'Jobs' : 'Stories';
 
 // JSON-LD: ItemList of evaluated stories (first page, default view only)
-const jsonLd = (safeSort === 'top' && safeFilter === 'all' && safeType === 'all' && safeModel === 'any' && page === 1) ? {
+const jsonLd = (safeSort === 'psq_desc' && safeFilter === 'all' && safeType === 'all' && safeModel === 'any' && page === 1) ? {
   '@context': 'https://schema.org',
   '@type': 'ItemList',
   name: 'Human Rights Observatory — Latest Evaluated Stories',
@@ -154,7 +154,7 @@ const jsonLd = (safeSort === 'top' && safeFilter === 'all' && safeType === 'all'
 
 // Canonical URL: include sort/filter/type/model but exclude pagination
 const canonicalParams = new URLSearchParams();
-if (safeSort !== 'top') canonicalParams.set('sort', safeSort);
+if (safeSort !== 'psq_desc') canonicalParams.set('sort', safeSort);
 if (safeFilter !== 'all') canonicalParams.set('filter', safeFilter);
 if (safeType !== 'all') canonicalParams.set('type', safeType);
 if (safeCtype !== 'all') canonicalParams.set('ctype', safeCtype);
@@ -258,10 +258,10 @@ function isLiteModel(id: string): boolean {
     <div class="filter-row">
       <span class="filter-label">sort:</span>
       {([
-        { value: 'top', label: 'top' },
-        { value: 'time', label: 'new' },
-        { value: 'score_desc', label: 'score' },
+        { value: 'psq_desc', label: 'psq' },
+        { value: 'top', label: 'rank' },
         { value: 'hn_points', label: 'points' },
+        { value: 'time', label: 'new' },
       ] as const).map((opt, i) => (
         <>
           {i > 0 && <span class="filter-sep"> | </span>}
@@ -273,13 +273,12 @@ function isLiteModel(id: string): boolean {
       ))}
     </div>
     <div class="filter-row">
-      <span class="filter-label">show:</span>
+      <span class="filter-label">psq:</span>
       {([
         { value: 'all', label: 'all' },
-        { value: 'evaluated', label: 'evaluated' },
-        { value: 'positive', label: 'positive' },
-        { value: 'negative', label: 'negative' },
-        { value: 'neutral', label: 'neutral' },
+        { value: 'psq_safe', label: 'safe' },
+        { value: 'psq_mixed', label: 'mixed' },
+        { value: 'psq_threat', label: 'threat' },
       ] as const).map((opt, i) => (
         <>
           {i > 0 && <span class="filter-sep"> | </span>}
@@ -392,24 +391,12 @@ function isLiteModel(id: string): boolean {
     <thead>
     <tr style="color: var(--fg-secondary); font-size: var(--font-xs); text-transform: uppercase; letter-spacing: 0.05em;">
       <th style="width: 28px; text-align: right; padding-right: 5px; font-weight: normal;">#</th>
+      <th width="55" style="text-align: center; font-weight: normal;">
+        <a href={sortUrl('psq_desc')} style={thStyle('psq_desc')} title="Psychoemotional Safety Quotient — click to sort">PSQ{sortArrow('psq_desc')}</a>
+      </th>
       <th style="text-align: left; font-weight: normal;">Title</th>
-      <th width="55" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('score_desc')} style={thStyle('score_desc')} title="Human Rights Compatibility Bias score — click to sort, click again to reverse">HRCB{sortArrow('score_desc')}</a>
-      </th>
-      <th width="55" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('psq_desc')} style={thStyle('psq_desc')} title="Psychoemotional Safety Quotient — experimental, ordinal only (rank-order meaningful, distances not). Click to sort.">PSQ{sortArrow('psq_desc')}</a>
-      </th>
-      <th width="55" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('editorial_desc')} style={thStyle('editorial_desc')} title="Editorial: what the content says — click to sort, click again to reverse">E{sortArrow('editorial_desc')}</a>
-      </th>
-      <th width="55" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('structural_desc')} style={thStyle('structural_desc')} title="Structural: what the site does — click to sort, click again to reverse">S{sortArrow('structural_desc')}</a>
-      </th>
       <th width="45" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('hn_points')} style={thStyle('hn_points')} title="HN score — click to sort, click again to reverse">Pts{sortArrow('hn_points')}</a>
-      </th>
-      <th width="55" style="text-align: center; font-weight: normal;">
-        <a href={sortUrl('time')} style={thStyle('time')} title="Time posted — click to sort, click again to reverse">Age{sortArrow('time')}</a>
+        <a href={sortUrl('hn_points')} style={thStyle('hn_points')} title="HN score — click to sort">Pts{sortArrow('hn_points')}</a>
       </th>
     </tr>
     </thead>
@@ -435,6 +422,9 @@ function isLiteModel(id: string): boolean {
         <>
         <tr style="border-top: 1px solid var(--bg-surface);">
           <td align="right" class="score-font" style="color: var(--fg-secondary); padding-right: 5px; vertical-align: top; padding-top: 4px;">{offset + i + 1}.</td>
+          <td align="center" class="score-font" style={`vertical-align: top; padding-top: 4px; color: ${hasPsq ? scoreToColor(psqNorm) : 'var(--fg-secondary)'};`}>
+            {hasPsq ? <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;">{formatPsqScore(story.psq_score)}</a> : '—'}
+          </td>
           <td style="vertical-align: top; padding: 4px 5px 2px 0;">
             <span class="titleline">
               <a href={story.url || `https://news.ycombinator.com/item?id=${story.hn_id}`}
@@ -462,80 +452,18 @@ function isLiteModel(id: string): boolean {
                   </a>
                 </>
               )}
-              {hasEval && (
-                <>
-                  {story.hcb_theme_tag && (
-                    <span class="badge" style="background: rgba(43,144,216,0.15); color: var(--color-violet); font-size: var(--font-xs); margin-left: 4px;"
-                          title={`Theme: ${story.hcb_theme_tag}`}>
-                      {story.hcb_theme_tag}
-                    </span>
-                  )}
-                  {story.hcb_classification && !isLiteOnly && (
-                    <span class="badge" style={`background: ${classificationColor(story.hcb_classification)}; color: ${classificationTextColor(story.hcb_classification)}; font-size: var(--font-xs); margin-left: 4px;`}
-                          title={story.hcb_classification}>
-                      {classLabel}
-                    </span>
-                  )}
-                  {(story.consensus_model_count ?? 0) >= 2 && story.consensus_score != null && (
-                    <span
-                      class="badge"
-                      style={`background: ${(story.consensus_spread ?? 0) > 0.3 ? 'rgba(217,119,6,0.15)' : 'rgba(43,144,216,0.10)'}; color: ${(story.consensus_spread ?? 0) > 0.3 ? 'var(--color-warning)' : 'var(--fg-emphasis)'}; font-size: var(--font-xs); margin-left: 3px;`}
-                      title={`Consensus across ${story.consensus_model_count} models: ${story.consensus_score > 0 ? '+' : ''}${story.consensus_score.toFixed(3)}${story.consensus_spread != null ? ` (spread ±${(story.consensus_spread / 2).toFixed(3)})` : ''}`}
-                    >&times;{story.consensus_model_count}{story.consensus_spread != null ? ` ±${(story.consensus_spread / 2).toFixed(2)}` : ''}</span>
-                  )}
-                  {rightsWashing && (
-                    <span
-                      class="badge"
-                      style="background: rgba(217,119,6,0.15); color: var(--color-warning); font-size: var(--font-xs); margin-left: 3px;"
-                      title={`Rights-washing: editorial says positive (E:${formatScore(story.hcb_editorial_mean)}) but structural behavior is negative (S:${formatScore(story.hcb_structural_mean)}). SETL: ${formatSetl(aggSetl)}`}
-                    >&#9888; says≠does</span>
-                  )}
-                </>
-              )}
+              {story.hn_by && <span> | </span>}
+              <span>{timeAgo(story.hn_time)}</span>
             </div>
-            {hasEval && miniScores.length > 0 && (
-              <div style="margin-top: 2px;">
-                <a href={`/item/${story.hn_id}`} style="text-decoration: none;">
-                  <MiniBar scores={miniScores} />
-                </a>
-              </div>
-            )}
-          </td>
-          <td align="center" class="score-font" style={`vertical-align: top; padding-top: 4px; color: ${isZero ? 'var(--color-nd)' : hasEval ? scoreToColor(displayScore) : 'var(--fg-secondary)'};`}>
-            {isZero
-              ? <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;" title="Score indeterminate — insufficient signal">ND</a>
-              : hasEval
-                ? isLiteOnly
-                  ? <a href={`/item/${story.hn_id}`} style="color: var(--color-orange); text-decoration: none;" title="Lite eval — editorial only">L</a>
-                  : <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;">{formatScore(displayScore)}</a>
-                : story.eval_status === 'failed'
-                  ? <a href={`/item/${story.hn_id}`} style="color: var(--color-negative); text-decoration: none;" title={`Failed: ${story.eval_error || 'unknown'}`}>F</a>
-                  : story.eval_status === 'evaluating'
-                    ? <span style="color: var(--channel-editorial);" title="Evaluating...">&#9881;</span>
-                    : story.eval_status === 'pending' || story.eval_status === 'queued'
-                      ? <span style="color: var(--color-warning);" title="Queued for evaluation">&hellip;</span>
-                      : '—'}
-          </td>
-          <td align="center" class="score-font" style={`vertical-align: top; padding-top: 4px; color: ${hasPsq ? scoreToColor(psqNorm) : 'var(--fg-secondary)'};`}>
-            {hasPsq ? <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;">{formatPsqScore(story.psq_score)}</a> : '—'}
-          </td>
-          <td align="center" class="score-font" style={`vertical-align: top; padding-top: 4px; color: ${story.hcb_editorial_mean != null ? scoreToColor(story.hcb_editorial_mean) : 'var(--fg-secondary)'};`}>
-            {story.hcb_editorial_mean != null ? <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;">{formatScore(story.hcb_editorial_mean)}</a> : '—'}
-          </td>
-          <td align="center" class="score-font" style={`vertical-align: top; padding-top: 4px; color: ${story.hcb_structural_mean != null ? scoreToColor(story.hcb_structural_mean) : 'var(--fg-secondary)'};`}>
-            {story.hcb_structural_mean != null ? <a href={`/item/${story.hn_id}`} style="color: inherit; text-decoration: none;">{formatScore(story.hcb_structural_mean)}</a> : '—'}
           </td>
           <td align="center" class="score-font" style="vertical-align: top; padding-top: 4px; color: var(--fg-secondary);">
             {story.hn_score ?? '—'}
-          </td>
-          <td align="center" class="score-font" style="vertical-align: top; padding-top: 4px; color: var(--fg-secondary); white-space: nowrap;">
-            {timeAgo(story.hn_time)}
           </td>
         </tr>
         {/* Pedagogical interstitial after stories 10 and 20 */}
         {i === 9 && selectedInsights[0] && (<>
           <tr>
-            <td colspan="8" style="padding: 8px 0;">
+            <td colspan="4" style="padding: 8px 0;">
               <div style="border-top: 1px dashed var(--color-border); border-bottom: 1px dashed var(--color-border); padding: 8px 10px; color: var(--fg-secondary); font-size: var(--font-xs); line-height: 1.6;">
                 <span style="color: var(--color-orange);">&#9670;</span>
                 {' '}{selectedInsights[0].text}
@@ -552,18 +480,14 @@ function isLiteModel(id: string): boolean {
           </tr>
           <tr class="interstitial-header" style="color: var(--fg-secondary); font-size: var(--font-xs); text-transform: uppercase; letter-spacing: 0.05em;">
             <td style="width: 28px; text-align: right; padding-right: 5px;">#</td>
+            <td width="55" style="text-align: center;">PSQ</td>
             <td style="text-align: left;">Title</td>
-            <td width="55" style="text-align: center;">HRCB</td>
-            <td width="55" style="text-align: center;" title="Psychoemotional Safety Quotient — experimental">PSQ</td>
-            <td width="55" style="text-align: center;" title="Editorial signal">E</td>
-            <td width="55" style="text-align: center;" title="Structural signal">S</td>
             <td width="45" style="text-align: center;">Pts</td>
-            <td width="55" style="text-align: center;">Age</td>
           </tr>
         </>)}
         {i === 19 && selectedInsights[1] && (<>
           <tr>
-            <td colspan="8" style="padding: 8px 0;">
+            <td colspan="4" style="padding: 8px 0;">
               <div style="border-top: 1px dashed var(--color-border); border-bottom: 1px dashed var(--color-border); padding: 8px 10px; color: var(--fg-secondary); font-size: var(--font-xs); line-height: 1.6;">
                 <span style="color: var(--color-orange);">&#9670;</span>
                 {' '}{selectedInsights[1].text}
@@ -580,13 +504,9 @@ function isLiteModel(id: string): boolean {
           </tr>
           <tr class="interstitial-header" style="color: var(--fg-secondary); font-size: var(--font-xs); text-transform: uppercase; letter-spacing: 0.05em;">
             <td style="width: 28px; text-align: right; padding-right: 5px;">#</td>
+            <td width="55" style="text-align: center;">PSQ</td>
             <td style="text-align: left;">Title</td>
-            <td width="55" style="text-align: center;">HRCB</td>
-            <td width="55" style="text-align: center;" title="Psychoemotional Safety Quotient — experimental">PSQ</td>
-            <td width="55" style="text-align: center;" title="Editorial signal">E</td>
-            <td width="55" style="text-align: center;" title="Structural signal">S</td>
             <td width="45" style="text-align: center;">Pts</td>
-            <td width="55" style="text-align: center;">Age</td>
           </tr>
         </>)}
         </>


### PR DESCRIPTION
## Summary
- Default sort changed from rank to **PSQ descending**
- Table columns simplified to **#, PSQ, Title, Points** (removed HRCB, E, S, Age)
- PSQ score displayed **to the left of the title**
- Added **PSQ filter**: safe (>6) | mixed (4-6) | threat (<4)
- Primary sort bar: psq | rank | points | new
- Age moved inline to the subtext row (by author | comments | age)

## Changes
- `site/src/pages/stories.astro` — layout, default sort, filter bar, column removal
- `site/src/lib/db-stories.ts` — added `psq_safe`, `psq_mixed`, `psq_threat` filter options

## Context
This makes PSQ the primary lens for the stories page, matching the observatory's evolving focus on psychoemotional safety as a first-class signal alongside HRCB. The full HRCB/E/S detail remains accessible on individual item pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)